### PR TITLE
fix: avoid leaking exception details in debug endpoints

### DIFF
--- a/mycoder-chat/backend/main.py
+++ b/mycoder-chat/backend/main.py
@@ -244,10 +244,11 @@ async def test_has_connection():
                 "has_response": response.json() if response.status_code == 200 else None,
                 "status_code": response.status_code
             }
-    except Exception as e:
+    except Exception:
+        logger.exception("HAS health check failed")
         return {
             "status": "failed",
-            "error": str(e)
+            "error": "HAS health check failed"
         }
 
 
@@ -262,10 +263,11 @@ async def test_llm_connection():
                 "llm_response": response.json() if response.status_code == 200 else None,
                 "status_code": response.status_code
             }
-    except Exception as e:
+    except Exception:
+        logger.exception("LLM server health check failed")
         return {
             "status": "failed",
-            "error": str(e)
+            "error": "LLM server health check failed"
         }
 
 


### PR DESCRIPTION
Fix CodeQL py/stack-trace-exposure by logging exceptions server-side and returning generic error strings for debug health checks.