### PR TITLE
ci: allow manual CodeQL runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
   schedule:
     - cron: "0 3 * * 1"
 


### PR DESCRIPTION
Add workflow_dispatch to CodeQL workflow so we can rerun scans after disabling default setup.