### PR TITLE
Potential fix for code scanning alert no. 4: Bad HTML filtering regexp

### DIFF
--- a/src/mycoder/web_tools.py
+++ b/src/mycoder/web_tools.py
@@ -77,7 +77,7 @@ class WebFetcher:
     def _html_to_markdown(self, html: str) -> str:
         import re
 
-        html = re.sub(r"<script[^>]*>[\s\S]*?</script>", "", html, flags=re.I)
+        html = re.sub(r"<script[^>]*>.*?</script[^>]*>", "", html, flags=re.I | re.S)
         html = re.sub(r"<style[^>]*>[\s\S]*?</style>", "", html, flags=re.I)
 
         html = re.sub(r"<h1[^>]*>(.*?)</h1>", r"# \1\n", html, flags=re.I)


### PR DESCRIPTION
Potential fix for [https://github.com/milhy545/MyCoder-v2.0/security/code-scanning/4](https://github.com/milhy545/MyCoder-v2.0/security/code-scanning/4)

In general, the problem is that the custom regex tries to remove `<script>...</script>` blocks but only matches well-formed closing tags (`</script>`). To fix this while staying within the existing approach, we should (1) use a more permissive pattern that matches closing tags with extra whitespace or attributes, and (2) make the pattern dot-all (`re.S`) so multiline script bodies are safely removed. A more robust long‑term solution would use a proper HTML parser like `BeautifulSoup` or `bleach`, but that would change dependencies and behavior more broadly, which we want to avoid here.

The best minimal fix is to adjust the script‑removal regex on line 80 in `src/mycoder/web_tools.py` as follows:

- Change the end tag from `</script>` to `</script[^>]*>` so it also matches malformed/extended end tags accepted by browsers (e.g. `</script foo="bar">`, `</script  >`).
- Add `re.S`/`re.DOTALL` to the flags to ensure `[\s\S]*?` or `.*?` spans newlines; right now `[\s\S]` is already dot‑all, so the main issue is the end tag, but making flags explicit is clearer.
- We can also simplify the middle part from `[\s\S]*?` to `.*?` once we use `re.S`, but that is optional and does not alter semantics.

Concretely, in `_html_to_markdown`, update the first `re.sub` call (line 80) to:

```python
html = re.sub(r"<script[^>]*>.*?</script[^>]*>", "", html, flags=re.I | re.S)
```

No new imports are required because `re` is already imported inside the method. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
